### PR TITLE
bump: docker base image, distribute using base

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@5.2.3
-  codacy_plugins_test: codacy/plugins-test@0.15.4
+  codacy: codacy/base@9.3.6
+  codacy_plugins_test: codacy/plugins-test@1.1.1
 
 workflows:
   version: 2


### PR DESCRIPTION
Bumps base image to remove vulnerabilities. Upstream docker image for mono is really slow to update (and thus has multiple vulnerabilities) and does little more than setting up the mono repo and installing runtime. We're already setting up the repo to build, might as well use our own base image. Rearranged  the docker file so the common step (setting up the repo) can be used both to build and distribute.