### PR TITLE
fix: update docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@9.3.6
+  codacy: codacy/base@10.1.0
   codacy_plugins_test: codacy/plugins-test@1.1.1
 
 workflows:


### PR DESCRIPTION
Using alpine as runtime base as it is more recently updated and has no vulnerabilities. This is also done in [codacy/codacy-sonar-visual-basic](https://github.com/codacy/codacy-sonar-visual-basic/blob/master/Dockerfile)