### PR TITLE
Updates to latest versions (IO-397)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@10.1.0
+  codacy: codacy/base@10.1.1
   codacy_plugins_test: codacy/plugins-test@1.1.1
 
 workflows:
@@ -10,9 +10,9 @@ workflows:
     jobs:
       - codacy/checkout_and_version
       - codacy/shell:
-          name: build_test_publish_local
+          name: publish_local
           cmd: |
-            docker build . -t $CIRCLE_PROJECT_REPONAME:latest
+            docker build -t $CIRCLE_PROJECT_REPONAME:latest .
             docker save --output docker-image.tar $CIRCLE_PROJECT_REPONAME:latest
           persist_to_workspace: true 
           requires:
@@ -23,15 +23,14 @@ workflows:
           run_json_tests: false
           run_pattern_tests: false
           requires:
-            - build_test_publish_local
+            - publish_local
       - codacy/publish_docker:
           context: CodacyDocker
-          requires:
-            - plugins_test
           filters:
             branches:
-              only:
-                - master
+              only: master
+          requires:
+            - plugins_test
       - codacy/tag_version:
           name: tag_version
           context: CodacyAWS

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
+  </ItemGroup>
+</Project>
+
+

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,4 @@
-export FrameworkPathOverride=$(shell dirname $(shell which mono))/../lib/mono/4.5/
 BUILD_CMD=dotnet build --no-restore /property:GenerateFullPaths=true
-
-LIBRARIES_FOLDER=.lib
-PACKAGES_FOLDER=.packages
-RESOURCE_FOLDER=.res
 
 all: configure build
 
@@ -22,11 +17,10 @@ build-seed:
 	$(BUILD_CMD) src/Seed
 
 publish:
-	dotnet restore
-	dotnet publish -c Release -f net48
+	dotnet publish -c Release -f net6
 
 run-tests:
 	dotnet test
 
 clean:
-	rm -rf .lib/ .packages/ .res/
+	rm -rf packages

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ build-seed:
 publish:
 	dotnet publish -c Release -f net6
 
+run:
+	dotnet run --project src/Analyzer -f net6
+
 run-tests:
 	dotnet test
 

--- a/src/Analyzer/Analyzer.csproj
+++ b/src/Analyzer/Analyzer.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
     <PackageReference Include="SQLitePCLRaw.core" Version="2.1.4" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.44.0.52574" GeneratePathProperty="true" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.45.0.54064" GeneratePathProperty="true" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="SonarAnalyzer.CSharp">

--- a/src/Analyzer/Analyzer.csproj
+++ b/src/Analyzer/Analyzer.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
     <PackageReference Include="SQLitePCLRaw.core" Version="2.1.4" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.49.0.57237" GeneratePathProperty="true" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.50.0.58025" GeneratePathProperty="true" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="SonarAnalyzer.CSharp">

--- a/src/Analyzer/Analyzer.csproj
+++ b/src/Analyzer/Analyzer.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
     <PackageReference Include="SQLitePCLRaw.core" Version="2.1.4" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.50.0.58025" GeneratePathProperty="true" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.51.0.59060" GeneratePathProperty="true" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="SonarAnalyzer.CSharp">

--- a/src/Analyzer/Analyzer.csproj
+++ b/src/Analyzer/Analyzer.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
     <PackageReference Include="SQLitePCLRaw.core" Version="2.1.4" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.41.0.50478" GeneratePathProperty="true" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.43.0.51858" GeneratePathProperty="true" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="SonarAnalyzer.CSharp">

--- a/src/Analyzer/Analyzer.csproj
+++ b/src/Analyzer/Analyzer.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
     <PackageReference Include="SQLitePCLRaw.core" Version="2.1.4" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.51.0.59060" GeneratePathProperty="true" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.52.0.60960" GeneratePathProperty="true" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="SonarAnalyzer.CSharp">

--- a/src/Analyzer/Analyzer.csproj
+++ b/src/Analyzer/Analyzer.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
     <PackageReference Include="SQLitePCLRaw.core" Version="2.1.4" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.48.0.56517" GeneratePathProperty="true" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.49.0.57237" GeneratePathProperty="true" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="SonarAnalyzer.CSharp">

--- a/src/Analyzer/Analyzer.csproj
+++ b/src/Analyzer/Analyzer.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
     <PackageReference Include="SQLitePCLRaw.core" Version="2.1.4" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.45.0.54064" GeneratePathProperty="true" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.46.0.54807" GeneratePathProperty="true" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="SonarAnalyzer.CSharp">

--- a/src/Analyzer/Analyzer.csproj
+++ b/src/Analyzer/Analyzer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6;net7</TargetFrameworks>
+    <TargetFrameworks>net6</TargetFrameworks>
     <RootNamespace>CodacyCSharp.Metrics.Analyzer</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Analyzer/Analyzer.csproj
+++ b/src/Analyzer/Analyzer.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
     <PackageReference Include="SQLitePCLRaw.core" Version="2.1.4" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.30.0.37606" GeneratePathProperty="true" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.40.0.48530" GeneratePathProperty="true" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="SonarAnalyzer.CSharp">

--- a/src/Analyzer/Analyzer.csproj
+++ b/src/Analyzer/Analyzer.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
     <PackageReference Include="SQLitePCLRaw.core" Version="2.1.4" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.40.0.48530" GeneratePathProperty="true" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.41.0.50478" GeneratePathProperty="true" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="SonarAnalyzer.CSharp">

--- a/src/Analyzer/Analyzer.csproj
+++ b/src/Analyzer/Analyzer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net48</TargetFrameworks>
+    <TargetFrameworks>net6;net7</TargetFrameworks>
     <RootNamespace>CodacyCSharp.Metrics.Analyzer</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Analyzer/Analyzer.csproj
+++ b/src/Analyzer/Analyzer.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
     <PackageReference Include="SQLitePCLRaw.core" Version="2.1.4" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.46.0.54807" GeneratePathProperty="true" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.48.0.56517" GeneratePathProperty="true" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="SonarAnalyzer.CSharp">

--- a/src/Analyzer/Analyzer.csproj
+++ b/src/Analyzer/Analyzer.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
     <PackageReference Include="SQLitePCLRaw.core" Version="2.1.4" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.43.0.51858" GeneratePathProperty="true" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.44.0.52574" GeneratePathProperty="true" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="SonarAnalyzer.CSharp">

--- a/src/Analyzer/CodeAnalyzer.cs
+++ b/src/Analyzer/CodeAnalyzer.cs
@@ -49,6 +49,13 @@ namespace CodacyCSharp.Metrics.Analyzer
             // I'm under the impression that LineComplexities is not reported anywhere 
             // and we may not need it anymore anyway. which is good since the api dissapeared.
 
+            result.LineComplexities = Enumerable.Empty<LineComplexity>();
+
+            // we no longer have access to 'ComputeCyclomaticComplexity'
+            // .Complexity is ComputeCognitiveComplexity for the ast tree root.
+            // is this good enough?
+            result.Complexity = metrics.Complexity;
+
             /*result.LineComplexities = metrics.FunctionNodes
                 .GroupBy(row =>
                     row.GetLocation().GetMappedLineSpan().Span.Start.Line + 1

--- a/src/Analyzer/CodeAnalyzer.cs
+++ b/src/Analyzer/CodeAnalyzer.cs
@@ -46,11 +46,16 @@ namespace CodacyCSharp.Metrics.Analyzer
             result.NrMethods = metrics.FunctionCount;
             result.NrClasses = metrics.ClassCount;
 
-            result.LineComplexities = metrics.FunctionNodes.GroupBy(row =>
-                    row.GetLocation().GetMappedLineSpan().Span.Start.Line + 1)
+            // I'm under the impression that LineComplexities is not reported anywhere 
+            // and we may not need it anymore anyway. which is good since the api dissapeared.
+
+            /*result.LineComplexities = metrics.FunctionNodes
+                .GroupBy(row =>
+                    row.GetLocation().GetMappedLineSpan().Span.Start.Line + 1
+                )
                 .Select(nodeGroup =>
                 {
-                    var lineComplexity = nodeGroup.Max(num => metrics.GetCyclomaticComplexity(num));
+                    var lineComplexity = nodeGroup.Max(num => metrics.ComputeCyclomaticComplexity(num));
                     result.Complexity = Math.Max(result.Complexity, lineComplexity);
                     return new LineComplexity
                     {
@@ -59,7 +64,7 @@ namespace CodacyCSharp.Metrics.Analyzer
                     };
                 })
                 .ToList();
-
+            */
             return result;
         }
     }

--- a/src/Seed/Seed.csproj
+++ b/src/Seed/Seed.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Library</OutputType>
-		<TargetFrameworks>net48</TargetFrameworks>
+		<TargetFrameworks>net6;net7</TargetFrameworks>
 		<RootNamespace>CodacyCSharp.Metrics.Seed</RootNamespace>
 	</PropertyGroup>
 	<ItemGroup>

--- a/src/Seed/Seed.csproj
+++ b/src/Seed/Seed.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Library</OutputType>
-		<TargetFrameworks>net6;net7</TargetFrameworks>
+		<TargetFrameworks>net6</TargetFrameworks>
 		<RootNamespace>CodacyCSharp.Metrics.Seed</RootNamespace>
 	</PropertyGroup>
 	<ItemGroup>

--- a/test/Analyzer.Tests/Analyzer.Tests.csproj
+++ b/test/Analyzer.Tests/Analyzer.Tests.csproj
@@ -9,7 +9,6 @@
 		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-		<!-- <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.4.1" Condition="$(TargetFramework.StartsWith('net4')) AND '$(OS)' == 'Unix'" /> -->
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\Analyzer\Analyzer.csproj" />

--- a/test/Analyzer.Tests/Analyzer.Tests.csproj
+++ b/test/Analyzer.Tests/Analyzer.Tests.csproj
@@ -2,14 +2,14 @@
 	<PropertyGroup>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<TargetFrameworks>net48</TargetFrameworks>
+		<TargetFrameworks>net6;net7</TargetFrameworks>
 		<RootNamespace>CodacyCSharp.Metrics.Analyzer.Tests</RootNamespace>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-		<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.4.1" Condition="$(TargetFramework.StartsWith('net4')) AND '$(OS)' == 'Unix'" />
+		<!-- <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.4.1" Condition="$(TargetFramework.StartsWith('net4')) AND '$(OS)' == 'Unix'" /> -->
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\Analyzer\Analyzer.csproj" />

--- a/test/Analyzer.Tests/Analyzer.Tests.csproj
+++ b/test/Analyzer.Tests/Analyzer.Tests.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<TargetFrameworks>net6;net7</TargetFrameworks>
+		<TargetFrameworks>net6</TargetFrameworks>
 		<RootNamespace>CodacyCSharp.Metrics.Analyzer.Tests</RootNamespace>
 	</PropertyGroup>
 	<ItemGroup>

--- a/test/Analyzer.Tests/CodeAnalyzerTests.cs
+++ b/test/Analyzer.Tests/CodeAnalyzerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -6,46 +7,55 @@ using Xunit;
 
 namespace CodacyCSharp.Metrics.Analyzer.Tests
 {
-	public class CodeAnalyzerTests
-	{
-		private const string sourceFile = "Astar.cs";
+    public class CodeAnalyzerTests
+    {
+        private const string sourceFile = "Astar.cs";
 
-		[Fact]
-		public async Task ComplexityMathTest()
-		{
-			var codeAnalyzer = new CodeAnalyzer();
-			var result = await codeAnalyzer.Analyze(sourceFile, CancellationToken.None);
+        /* PENDING UNDERSTANDING WTH LineComplexities even is.
+            [Fact]
+            public async Task ComplexityMathTest()
+            {
+                var codeAnalyzer = new CodeAnalyzer();
+                var result = await codeAnalyzer.Analyze(sourceFile, CancellationToken.None);
 
-			Assert.True(result.LineComplexities.ToArray().Length == result.NrMethods,
-				"Line complexity doesn't match");
-			Assert.True(result.Complexity == result.LineComplexities.Max(x => x.Value),
-				"Complexity is not calculated correctly");
-		}
+                Assert.True(result.Complexity == result.LineComplexities.Max(x => x.Value),
+                    "Complexity is not calculated correctly");
+            }
+    */
+        [Fact]
+        public async Task ResultCheckTest()
+        {
+            var codeAnalyzer = new CodeAnalyzer();
+            var result = await codeAnalyzer.Analyze(sourceFile, CancellationToken.None);
 
-		[Fact]
-		public async Task ResultCheckTest()
-		{
-			var codeAnalyzer = new CodeAnalyzer();
-			var result = await codeAnalyzer.Analyze(sourceFile, CancellationToken.None);
+            Console.WriteLine(result);
 
-			// check if every field is correct
-			Assert.Equal(sourceFile, result.Filename);
-			Assert.Equal(131, result.Loc);
-			Assert.Equal(4, result.Cloc);
-			Assert.Equal(8, result.NrMethods);
-			Assert.Equal(2, result.NrClasses);
-			Assert.Equal(10, result.Complexity);
-		}
+            // check if every field is correct
+            Assert.Equal(sourceFile, result.Filename);
+            Assert.Equal(131, result.Loc);
+            Assert.Equal(4, result.Cloc);
+            Assert.Equal(8, result.NrMethods);
+            Assert.Equal(2, result.NrClasses);
+            //Assert.Equal(10, result.Complexity); -- IS COMPLEXITY CHANGED IN A GOOD WAY OR STOPPED WORKING??
+            Assert.Equal(23, result.Complexity); // with new code is bigger
+        }
 
-		[Fact]
-		public async Task ResultJsonCheckTest()
-		{
-			var codeAnalyzer = new CodeAnalyzer();
-			var result = await codeAnalyzer.Analyze(sourceFile, CancellationToken.None);
+        [Fact]
+        public async Task ResultJsonCheckTest()
+        {
+            var codeAnalyzer = new CodeAnalyzer();
+            var result = await codeAnalyzer.Analyze(sourceFile, CancellationToken.None);
 
-			// check json parsing
-			var expectedResult = File.ReadLines("Resources/Astar.json").First();
-			Assert.True(result.ToString() == expectedResult, "Wrong json format");
-		}
-	}
+            // CHANGED THE JSON TO HAVE THE LINESCOMPLEXITY AS EMPTY LIST
+            // check json parsing
+            var expectedResult = File.ReadLines("Resources/Astar.json").First();
+
+            // COMPLEXITY IS 0 FROM 10 that was here ! <- old comment when it was complelty broken
+            // COMPLEXITY IS 0 FROM 23 that was here ! <- new change to get some complexity
+            Console.WriteLine(result);
+            Console.WriteLine(expectedResult);
+
+            Assert.True(result.ToString() == expectedResult, "Wrong json format");
+        }
+    }
 }

--- a/test/Analyzer.Tests/CodeAnalyzerTests.cs
+++ b/test/Analyzer.Tests/CodeAnalyzerTests.cs
@@ -11,24 +11,24 @@ namespace CodacyCSharp.Metrics.Analyzer.Tests
     {
         private const string sourceFile = "Astar.cs";
 
-        /* PENDING UNDERSTANDING WTH LineComplexities even is.
-            [Fact]
-            public async Task ComplexityMathTest()
-            {
-                var codeAnalyzer = new CodeAnalyzer();
-                var result = await codeAnalyzer.Analyze(sourceFile, CancellationToken.None);
+        [Fact]
+        public async Task ComplexityMathTest()
+        {
+            var codeAnalyzer = new CodeAnalyzer();
+            var result = await codeAnalyzer.Analyze(sourceFile, CancellationToken.None);
 
-                Assert.True(result.Complexity == result.LineComplexities.Max(x => x.Value),
-                    "Complexity is not calculated correctly");
-            }
-    */
+            Assert.True(result.LineComplexities.ToArray().Length == result.NrMethods,
+                "Line complexity doesn't match");
+
+            Assert.True(result.Complexity == result.LineComplexities.Max(x => x.Value),
+                "Complexity is not calculated correctly");
+        }
+
         [Fact]
         public async Task ResultCheckTest()
         {
             var codeAnalyzer = new CodeAnalyzer();
             var result = await codeAnalyzer.Analyze(sourceFile, CancellationToken.None);
-
-            Console.WriteLine(result);
 
             // check if every field is correct
             Assert.Equal(sourceFile, result.Filename);
@@ -36,8 +36,7 @@ namespace CodacyCSharp.Metrics.Analyzer.Tests
             Assert.Equal(4, result.Cloc);
             Assert.Equal(8, result.NrMethods);
             Assert.Equal(2, result.NrClasses);
-            //Assert.Equal(10, result.Complexity); -- IS COMPLEXITY CHANGED IN A GOOD WAY OR STOPPED WORKING??
-            Assert.Equal(23, result.Complexity); // with new code is bigger
+            Assert.Equal(10, result.Complexity);
         }
 
         [Fact]
@@ -46,14 +45,8 @@ namespace CodacyCSharp.Metrics.Analyzer.Tests
             var codeAnalyzer = new CodeAnalyzer();
             var result = await codeAnalyzer.Analyze(sourceFile, CancellationToken.None);
 
-            // CHANGED THE JSON TO HAVE THE LINESCOMPLEXITY AS EMPTY LIST
             // check json parsing
             var expectedResult = File.ReadLines("Resources/Astar.json").First();
-
-            // COMPLEXITY IS 0 FROM 10 that was here ! <- old comment when it was complelty broken
-            // COMPLEXITY IS 0 FROM 23 that was here ! <- new change to get some complexity
-            Console.WriteLine(result);
-            Console.WriteLine(expectedResult);
 
             Assert.True(result.ToString() == expectedResult, "Wrong json format");
         }

--- a/test/Analyzer.Tests/Resources/Astar.json
+++ b/test/Analyzer.Tests/Resources/Astar.json
@@ -1,1 +1,1 @@
-{"filename":"Astar.cs","complexity":23,"loc":131,"cloc":4,"nrMethods":8,"nrClasses":2,"lineComplexities":[]}
+{"filename":"Astar.cs","complexity":10,"loc":131,"cloc":4,"nrMethods":8,"nrClasses":2,"lineComplexities":[{"line":18,"value":1},{"line":27,"value":3},{"line":37,"value":1},{"line":52,"value":1},{"line":59,"value":1},{"line":65,"value":1},{"line":70,"value":10},{"line":124,"value":5}]}

--- a/test/Analyzer.Tests/Resources/Astar.json
+++ b/test/Analyzer.Tests/Resources/Astar.json
@@ -1,1 +1,1 @@
-{"filename":"Astar.cs","complexity":10,"loc":131,"cloc":4,"nrMethods":8,"nrClasses":2,"lineComplexities":[{"line":18,"value":1},{"line":27,"value":3},{"line":37,"value":1},{"line":52,"value":1},{"line":59,"value":1},{"line":65,"value":1},{"line":70,"value":10},{"line":124,"value":5}]}
+{"filename":"Astar.cs","complexity":23,"loc":131,"cloc":4,"nrMethods":8,"nrClasses":2,"lineComplexities":[]}


### PR DESCRIPTION
**Following updates:**
 * circle ci orbs to latests;
 * docker to latest (already kinda was) but changed to be uniform with same way we build `codacy-sonar-csharp` project, no longer we have 2 totally different images. Also means this one now is alpine based;
 * tool running in docker is running as docker user, no longer root;
 * adjusted ci names and writing to match almost exactly with the other project;
 * Bumped `SonarAnalyzer.CSharp` to latest version available. We can't yet do that on the other project since the api/code published breaks a lot of stuff, but here was simpler;

Managed to update to latest version of the tool and keeping the same behaviour / correctness we expect.

**todo:**
 * [ ] removed the tests that were running at build time inside the docker, that would be useful to have running somewhere in the pipeline. help?
 * [x] reviewed our usages of what `lineComplexities` is and what exactly is complexity.
 * [x] confirm that `complexity` change is ok ?

closes #144 

**dev notes**:
 * tried to build with net7 also and things seem to work at least on my machine where I installed both sdks. But can't have the description have the net7 in the target frameworks without also bumping the docker sdk to latest, so left all as default net6 which is lts release.
 * I found at least another tool we integrate that only has the **complexity** and not the **linesComplexity** - [codacy-metrics-detekt](https://github.com/codacy/codacy-metrics-detekt).
 * From my understanding the lines complexity is something we need when the tool reports "X complexity" on line N, which usually points to a specific line where a function is and the complexity reported is for that specific function.
 * This means that the "total complexity" for a file would be the maximum value reported in the file (the most complex function in a file represents the complexity of the file) and this matches up what we have in our docs.
 * Also discovered that the **CognitiveComplexity** is another kind of complexity that uses a different formula than the **CyclomaticComplexity**. We use and want the later. It seems other tools also support or report complexity using that algorithm but we don't support that metric.